### PR TITLE
SWI-6558: serialize nightly with lock('ios-simulator')

### DIFF
--- a/.jenkins/Jenkinsfile-Nightly
+++ b/.jenkins/Jenkinsfile-Nightly
@@ -1,5 +1,8 @@
 pipeline {
     agent any
+    options {
+        lock('ios-simulator')
+    }
     triggers {
         cron('H 0 * * *')
     }


### PR DESCRIPTION
## Problem

This is the only iOS sample-app nightly whose `.jenkins/Jenkinsfile-Nightly` is **missing** `options { lock('ios-simulator') }`. The other five (karaoke, dj, vocal-fx, guitar-effect, karaoke-ivs) all carry it from SWI-6558 (PR #3) — this repo was missed.

The iOS nightlies share `cron('H 0 * * *')`; the `H` staggers them across the 0:00 hour and the lock serializes them on the single buildmac node. Without the lock, this job can run **concurrently** with another iOS nightly and contend over shared CoreSimulator state.

Observed live on 2026-06-17: this job, run concurrently with the Karaoke nightly, failed with `Failed to clone device named 'iPhone 17'. … Device was allocated but was stuck in creation state.` — the other job's simulator hygiene collided with this one's clone-creation.

## Fix

Add `options { lock('ios-simulator') }`, matching the rest of the fleet. No other change.

This is the locking half (SWI-6558) of the work; the `scripts/test.sh` simulator-hygiene fixes for the three apps in this repo are tracked separately under SWI-6589.