### PR TITLE
SWI-6589: reset simulator state in test.sh to fix Xcode 26 nightly flake

### DIFF
--- a/DuckingAndSoundEffectsApp/scripts/test.sh
+++ b/DuckingAndSoundEffectsApp/scripts/test.sh
@@ -1,14 +1,85 @@
 #!/bin/bash
-
-set -eu
+set -euo pipefail
 
 PROJECT_DIR="$(git rev-parse --show-toplevel)"
 XCODE_PROJECT_PATH="${PROJECT_DIR}/DuckingAndSoundEffectsApp/DuckingAndSoundEffectsApp.xcodeproj"
-SCHEME_NAME="DuckingAndSoundEffectsApp"
-DESTINATION="platform=iOS Simulator,name=iPhone 17"
+DERIVED_DATA="${PROJECT_DIR}/build/XcodeDerivedData"
+SCHEME="DuckingAndSoundEffectsApp"
+DEVICE_NAME="iPhone 17"
 
-xcodebuild clean test \
-  -project "$XCODE_PROJECT_PATH" \
-  -scheme "$SCHEME_NAME" \
-  -derivedDataPath "${PROJECT_DIR}/build/XcodeDerivedData" \
-  -destination "$DESTINATION"
+# --- Simulator hygiene: start from clean, known-good state ---
+# Under Xcode 26, xcodebuild's parallel-test clone path leaks "Clone N of ..."
+# devices when it aborts; they accumulate on the long-lived node and drive
+# CoreSimulator into the state that triggers the DVTiPhoneSimulator launchSession
+# assertion (SIGABRT / exit 134) or "stuck in creation state" clone failures.
+# Clear them before every run. Safe only under lock('ios-simulator') (exclusive
+# simulator access) -- see .jenkins/Jenkinsfile-Nightly.
+echo "Cleaning simulator state..."
+xcrun simctl shutdown all || true
+xcrun simctl delete unavailable || true
+# `|| true`: grep exits 1 when there are no clones, which would abort under pipefail.
+clone_udids="$(xcrun simctl list devices | grep -E "Clone [0-9]+ of " | grep -oE '[0-9A-Fa-f-]{36}' || true)"
+for udid in ${clone_udids}; do xcrun simctl delete "${udid}" || true; done
+
+# Resolve a usable UDID for the target device (exact name match, not "... Pro").
+# `|| true`: tolerate no-match (handled by the guard below) and head's SIGPIPE under pipefail.
+UDID="$(xcrun simctl list devices available \
+  | grep -E "^[[:space:]]+${DEVICE_NAME} \(" \
+  | head -1 \
+  | grep -oE '[0-9A-Fa-f-]{36}' || true)"
+if [ -z "${UDID}" ]; then
+  echo "Device '${DEVICE_NAME}' not found. Available:"; xcrun simctl list devices available
+  exit 1
+fi
+echo "Using ${DEVICE_NAME} (${UDID})"
+
+# Boot the pinned device and wait until fully booted before testing.
+xcrun simctl erase "${UDID}" || true   # targeted erase; device is shut down above
+xcrun simctl boot "${UDID}" || true
+xcrun simctl bootstatus "${UDID}" -b || true
+
+DESTINATION="platform=iOS Simulator,id=${UDID}"
+
+xcrun xcodebuild clean \
+  -project "${XCODE_PROJECT_PATH}" \
+  -scheme "${SCHEME}" \
+  -derivedDataPath "${DERIVED_DATA}" \
+  -destination "${DESTINATION}"
+
+# Run tests. Retry ONCE, and only for the known simulator-runner bootstrap
+# transient ("never finished bootstrapping" / "signal term while preparing to
+# run tests"). Any other failure -- a real test failure or the launchSession
+# crash -- exits immediately and is never masked.
+max_attempts=2
+test_log="$(mktemp)"
+attempt=1
+while :; do
+  set +e
+  xcrun xcodebuild test \
+    -project "${XCODE_PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -derivedDataPath "${DERIVED_DATA}" \
+    -destination "${DESTINATION}" \
+    -parallel-testing-enabled NO 2>&1 | tee "${test_log}"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    break
+  fi
+  if [ "${attempt}" -lt "${max_attempts}" ] \
+     && grep -qE "never finished bootstrapping|signal term while preparing to run tests" "${test_log}"; then
+    attempt=$((attempt + 1))
+    echo "Test runner failed to bootstrap (known transient); rebooting simulator and retrying (attempt ${attempt}/${max_attempts})..."
+    xcrun simctl shutdown "${UDID}" || true
+    xcrun simctl boot "${UDID}" || true
+    xcrun simctl bootstatus "${UDID}" -b || true
+    continue
+  fi
+  rm -f "${test_log}"
+  xcrun simctl shutdown "${UDID}" || true
+  exit "${rc}"
+done
+rm -f "${test_log}"
+
+# Leave the node clean for the next job.
+xcrun simctl shutdown "${UDID}" || true

--- a/OnlineRadioApp/scripts/test.sh
+++ b/OnlineRadioApp/scripts/test.sh
@@ -1,14 +1,85 @@
 #!/bin/bash
-
-set -eu
+set -euo pipefail
 
 PROJECT_DIR="$(git rev-parse --show-toplevel)"
 XCODE_PROJECT_PATH="${PROJECT_DIR}/OnlineRadioApp/OnlineRadioApp.xcodeproj"
-SCHEME_NAME="OnlineRadioApp"
-DESTINATION="platform=iOS Simulator,name=iPhone 17"
+DERIVED_DATA="${PROJECT_DIR}/build/XcodeDerivedData"
+SCHEME="OnlineRadioApp"
+DEVICE_NAME="iPhone 17"
 
-xcodebuild clean test \
-  -project "$XCODE_PROJECT_PATH" \
-  -scheme "$SCHEME_NAME" \
-  -derivedDataPath "${PROJECT_DIR}/build/XcodeDerivedData" \
-  -destination "$DESTINATION"
+# --- Simulator hygiene: start from clean, known-good state ---
+# Under Xcode 26, xcodebuild's parallel-test clone path leaks "Clone N of ..."
+# devices when it aborts; they accumulate on the long-lived node and drive
+# CoreSimulator into the state that triggers the DVTiPhoneSimulator launchSession
+# assertion (SIGABRT / exit 134) or "stuck in creation state" clone failures.
+# Clear them before every run. Safe only under lock('ios-simulator') (exclusive
+# simulator access) -- see .jenkins/Jenkinsfile-Nightly.
+echo "Cleaning simulator state..."
+xcrun simctl shutdown all || true
+xcrun simctl delete unavailable || true
+# `|| true`: grep exits 1 when there are no clones, which would abort under pipefail.
+clone_udids="$(xcrun simctl list devices | grep -E "Clone [0-9]+ of " | grep -oE '[0-9A-Fa-f-]{36}' || true)"
+for udid in ${clone_udids}; do xcrun simctl delete "${udid}" || true; done
+
+# Resolve a usable UDID for the target device (exact name match, not "... Pro").
+# `|| true`: tolerate no-match (handled by the guard below) and head's SIGPIPE under pipefail.
+UDID="$(xcrun simctl list devices available \
+  | grep -E "^[[:space:]]+${DEVICE_NAME} \(" \
+  | head -1 \
+  | grep -oE '[0-9A-Fa-f-]{36}' || true)"
+if [ -z "${UDID}" ]; then
+  echo "Device '${DEVICE_NAME}' not found. Available:"; xcrun simctl list devices available
+  exit 1
+fi
+echo "Using ${DEVICE_NAME} (${UDID})"
+
+# Boot the pinned device and wait until fully booted before testing.
+xcrun simctl erase "${UDID}" || true   # targeted erase; device is shut down above
+xcrun simctl boot "${UDID}" || true
+xcrun simctl bootstatus "${UDID}" -b || true
+
+DESTINATION="platform=iOS Simulator,id=${UDID}"
+
+xcrun xcodebuild clean \
+  -project "${XCODE_PROJECT_PATH}" \
+  -scheme "${SCHEME}" \
+  -derivedDataPath "${DERIVED_DATA}" \
+  -destination "${DESTINATION}"
+
+# Run tests. Retry ONCE, and only for the known simulator-runner bootstrap
+# transient ("never finished bootstrapping" / "signal term while preparing to
+# run tests"). Any other failure -- a real test failure or the launchSession
+# crash -- exits immediately and is never masked.
+max_attempts=2
+test_log="$(mktemp)"
+attempt=1
+while :; do
+  set +e
+  xcrun xcodebuild test \
+    -project "${XCODE_PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -derivedDataPath "${DERIVED_DATA}" \
+    -destination "${DESTINATION}" \
+    -parallel-testing-enabled NO 2>&1 | tee "${test_log}"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    break
+  fi
+  if [ "${attempt}" -lt "${max_attempts}" ] \
+     && grep -qE "never finished bootstrapping|signal term while preparing to run tests" "${test_log}"; then
+    attempt=$((attempt + 1))
+    echo "Test runner failed to bootstrap (known transient); rebooting simulator and retrying (attempt ${attempt}/${max_attempts})..."
+    xcrun simctl shutdown "${UDID}" || true
+    xcrun simctl boot "${UDID}" || true
+    xcrun simctl bootstatus "${UDID}" -b || true
+    continue
+  fi
+  rm -f "${test_log}"
+  xcrun simctl shutdown "${UDID}" || true
+  exit "${rc}"
+done
+rm -f "${test_log}"
+
+# Leave the node clean for the next job.
+xcrun simctl shutdown "${UDID}" || true

--- a/VoiceCommunicationApp/scripts/test.sh
+++ b/VoiceCommunicationApp/scripts/test.sh
@@ -1,14 +1,85 @@
 #!/bin/bash
-
-set -eu
+set -euo pipefail
 
 PROJECT_DIR="$(git rev-parse --show-toplevel)"
 XCODE_PROJECT_PATH="${PROJECT_DIR}/VoiceCommunicationApp/VoiceCommunicationApp.xcodeproj"
-SCHEME_NAME="VoiceCommunicationApp"
-DESTINATION="platform=iOS Simulator,name=iPhone 17"
+DERIVED_DATA="${PROJECT_DIR}/build/XcodeDerivedData"
+SCHEME="VoiceCommunicationApp"
+DEVICE_NAME="iPhone 17"
 
-xcodebuild clean test \
-  -project "$XCODE_PROJECT_PATH" \
-  -scheme "$SCHEME_NAME" \
-  -derivedDataPath "${PROJECT_DIR}/build/XcodeDerivedData" \
-  -destination "$DESTINATION"
+# --- Simulator hygiene: start from clean, known-good state ---
+# Under Xcode 26, xcodebuild's parallel-test clone path leaks "Clone N of ..."
+# devices when it aborts; they accumulate on the long-lived node and drive
+# CoreSimulator into the state that triggers the DVTiPhoneSimulator launchSession
+# assertion (SIGABRT / exit 134) or "stuck in creation state" clone failures.
+# Clear them before every run. Safe only under lock('ios-simulator') (exclusive
+# simulator access) -- see .jenkins/Jenkinsfile-Nightly.
+echo "Cleaning simulator state..."
+xcrun simctl shutdown all || true
+xcrun simctl delete unavailable || true
+# `|| true`: grep exits 1 when there are no clones, which would abort under pipefail.
+clone_udids="$(xcrun simctl list devices | grep -E "Clone [0-9]+ of " | grep -oE '[0-9A-Fa-f-]{36}' || true)"
+for udid in ${clone_udids}; do xcrun simctl delete "${udid}" || true; done
+
+# Resolve a usable UDID for the target device (exact name match, not "... Pro").
+# `|| true`: tolerate no-match (handled by the guard below) and head's SIGPIPE under pipefail.
+UDID="$(xcrun simctl list devices available \
+  | grep -E "^[[:space:]]+${DEVICE_NAME} \(" \
+  | head -1 \
+  | grep -oE '[0-9A-Fa-f-]{36}' || true)"
+if [ -z "${UDID}" ]; then
+  echo "Device '${DEVICE_NAME}' not found. Available:"; xcrun simctl list devices available
+  exit 1
+fi
+echo "Using ${DEVICE_NAME} (${UDID})"
+
+# Boot the pinned device and wait until fully booted before testing.
+xcrun simctl erase "${UDID}" || true   # targeted erase; device is shut down above
+xcrun simctl boot "${UDID}" || true
+xcrun simctl bootstatus "${UDID}" -b || true
+
+DESTINATION="platform=iOS Simulator,id=${UDID}"
+
+xcrun xcodebuild clean \
+  -project "${XCODE_PROJECT_PATH}" \
+  -scheme "${SCHEME}" \
+  -derivedDataPath "${DERIVED_DATA}" \
+  -destination "${DESTINATION}"
+
+# Run tests. Retry ONCE, and only for the known simulator-runner bootstrap
+# transient ("never finished bootstrapping" / "signal term while preparing to
+# run tests"). Any other failure -- a real test failure or the launchSession
+# crash -- exits immediately and is never masked.
+max_attempts=2
+test_log="$(mktemp)"
+attempt=1
+while :; do
+  set +e
+  xcrun xcodebuild test \
+    -project "${XCODE_PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -derivedDataPath "${DERIVED_DATA}" \
+    -destination "${DESTINATION}" \
+    -parallel-testing-enabled NO 2>&1 | tee "${test_log}"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    break
+  fi
+  if [ "${attempt}" -lt "${max_attempts}" ] \
+     && grep -qE "never finished bootstrapping|signal term while preparing to run tests" "${test_log}"; then
+    attempt=$((attempt + 1))
+    echo "Test runner failed to bootstrap (known transient); rebooting simulator and retrying (attempt ${attempt}/${max_attempts})..."
+    xcrun simctl shutdown "${UDID}" || true
+    xcrun simctl boot "${UDID}" || true
+    xcrun simctl bootstatus "${UDID}" -b || true
+    continue
+  fi
+  rm -f "${test_log}"
+  xcrun simctl shutdown "${UDID}" || true
+  exit "${rc}"
+done
+rm -f "${test_log}"
+
+# Leave the node clean for the next job.
+xcrun simctl shutdown "${UDID}" || true


### PR DESCRIPTION
## Problem

Shared with the other iOS sample-app nightlies: under **Xcode 26**, a passing UI test can still fail the build because `xcodebuild` aborts in CoreSimulator teardown (`DVTiPhoneSimulator … (launchSession) should not be nil` → SIGABRT → `exit 134`) or fails to clone the device (`Failed to clone device … stuck in creation state` → exit 65). Root cause is the Xcode 26 parallel-test **clone** path leaking `Clone N of …` devices on the long-lived node (fine on Xcode 16; see [Apple forum 817089](https://developer.apple.com/forums/thread/817089)).

This repo runs **three** apps sequentially in one nightly job, so all three scripts are fixed.

## Fix

Same pattern proven in `karaoke-app-ios` (PR #4), applied to each of `VoiceCommunicationApp/`, `DuckingAndSoundEffectsApp/`, and `OnlineRadioApp/scripts/test.sh`:

- Pre-run hygiene: `simctl shutdown all`, `delete unavailable`, delete leaked `Clone N` devices.
- Resolve → `erase` → `boot` → `bootstatus` a pinned `iPhone 17`; pin `-destination "…,id=<UDID>"`.
- `-parallel-testing-enabled NO`; `set -euo pipefail`; narrow single retry only on the bootstrap transient.

`shellcheck` clean (all three).

## Related

This repo was also the **only** iOS nightly missing `lock('ios-simulator')` in its Jenkinsfile — added separately in #3 (SWI-6558). The lock is a prerequisite for this hygiene fix to be safe (the hygiene block clears global simulator state and assumes exclusive access). Merge both.